### PR TITLE
Send placements in the messages enabled capability field.

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -48,7 +48,6 @@ class RegistrationController < ApplicationController
     rh = tool_proxy.tool_profile.resource_handler.first
     mh = rh.message.first
     mh.parameter = parameters.map { |var, val| IMS::LTI::Models::Parameter.new(name: val['name'], variable: var) }
-    rh.ext_placements = placements.keys
     mh.enabled_capability = placements.keys
     tool_proxy.custom = tool_settings if tool_settings
     registration.update(tool_proxy_json: tool_proxy.to_json)

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -49,6 +49,7 @@ class RegistrationController < ApplicationController
     mh = rh.message.first
     mh.parameter = parameters.map { |var, val| IMS::LTI::Models::Parameter.new(name: val['name'], variable: var) }
     rh.ext_placements = placements.keys
+    mh.enabled_capability = placements.keys
     tool_proxy.custom = tool_settings if tool_settings
     registration.update(tool_proxy_json: tool_proxy.to_json)
 

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -48,6 +48,7 @@ class RegistrationController < ApplicationController
     rh = tool_proxy.tool_profile.resource_handler.first
     mh = rh.message.first
     mh.parameter = parameters.map { |var, val| IMS::LTI::Models::Parameter.new(name: val['name'], variable: var) }
+    rh.ext_placements = placements.keys
     mh.enabled_capability = placements.keys
     tool_proxy.custom = tool_settings if tool_settings
     registration.update(tool_proxy_json: tool_proxy.to_json)

--- a/app/views/guide/home.html.erb
+++ b/app/views/guide/home.html.erb
@@ -6,6 +6,6 @@
     <br />
     <h4>LTI 2 Config</h4>
     <p>Paste this url into your tool consumer to register this tool:</p>
-    <p><span class="form-control"><%= tool_registration_url %></span></p>
+    <p><input type="text" onClick="this.select()" class="form-control" value="<%= tool_registration_url %>" /></p>
   </form>
 </div>


### PR DESCRIPTION
Placements are still sent in the resource handler as well.

fixes PLAT-1156

Test Plan
- make sure the tool proxy json now includes a 'enabled capability' field nested in the message that contains placements.
